### PR TITLE
fix(meta): fixes domain verification by meta tag

### DIFF
--- a/src/Handler/LookupHandler.php
+++ b/src/Handler/LookupHandler.php
@@ -18,6 +18,6 @@ class LookupHandler implements HandlerInterface
 
     public function get_meta_tags(...$arguments)
     {
-        return get_meta_tags($arguments);
+        return get_meta_tags(...$arguments);
     }
 }


### PR DESCRIPTION
fixes error: get_meta_tags(): Argument #1 ($filename) must be of type string, array given